### PR TITLE
Potential fix for code scanning alert no. 33: Replacement of a substring with itself

### DIFF
--- a/lib/src/repository/implement/worldRaceRepositoryFromHtmlImpl.ts
+++ b/lib/src/repository/implement/worldRaceRepositoryFromHtmlImpl.ts
@@ -170,8 +170,7 @@ export class WorldRaceRepositoryFromHtmlImpl
                                       .text()
                                       .replace('G1', 'GⅠ')
                                       .replace('G2', 'GⅡ')
-                                      .replace('G3', 'GⅢ')
-                                      .replace('Listed', 'Listed');
+                                      .replace('G3', 'GⅢ');
                             const grade: WorldGradeType =
                                 gradeText === '' ? '格付けなし' : gradeText;
 


### PR DESCRIPTION
Potential fix for [https://github.com/taichi6930/race-schedule-api/security/code-scanning/33](https://github.com/taichi6930/race-schedule-api/security/code-scanning/33)

To fix the problem, we need to remove the redundant replacement of `'Listed'` with `'Listed'`. This can be done by simply deleting the line that performs this unnecessary replacement. This change will not affect the existing functionality since the replacement does not alter the string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
