### PR TITLE
Potential fix for code scanning alert no. 38: Overly permissive regular expression range

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,11 @@ module.exports = {
     },
     reporters: [
         'default',
-        ["jest-html-reporters", {
-            "darkTheme": true
-        }]
+        [
+            'jest-html-reporters',
+            {
+                darkTheme: true,
+            },
+        ],
     ],
 };

--- a/lib/src/utility/raceName.ts
+++ b/lib/src/utility/raceName.ts
@@ -343,7 +343,7 @@ export const processWorldRaceName = (
     raceInfo: WorldRaceDataForRaceName,
 ): string => {
     return raceInfo.name
-        .replace(/[Ａ-Ｚａ-ｚ０-９！-～]/g, function (s) {
+        .replace(/[Ａ-Ｚａ-ｚ０-９！-＃＄％＆（）＊＋，－．／：；＜＝＞？＠［＼］＾＿｀｛｜｝～]/g, function (s) {
             return String.fromCharCode(s.charCodeAt(0) - 0xfee0);
         })
         .replace(/ステークス/, 'S')

--- a/lib/src/utility/raceName.ts
+++ b/lib/src/utility/raceName.ts
@@ -343,9 +343,12 @@ export const processWorldRaceName = (
     raceInfo: WorldRaceDataForRaceName,
 ): string => {
     return raceInfo.name
-        .replace(/[Ａ-Ｚａ-ｚ０-９！-＃＄％＆（）＊＋，－．／：；＜＝＞？＠［＼］＾＿｀｛｜｝～]/g, function (s) {
-            return String.fromCharCode(s.charCodeAt(0) - 0xfee0);
-        })
+        .replace(
+            /[Ａ-Ｚａ-ｚ０-９！-＃＄％＆（）＊＋，－．／：；＜＝＞？＠［＼］＾＿｀｛｜｝～]/g,
+            function (s) {
+                return String.fromCharCode(s.charCodeAt(0) - 0xfee0);
+            },
+        )
         .replace(/ステークス/, 'S')
         .replace(/カップ/, 'C')
         .replace(/サラ系/, '')


### PR DESCRIPTION
Potential fix for [https://github.com/taichi6930/race-schedule-api/security/code-scanning/38](https://github.com/taichi6930/race-schedule-api/security/code-scanning/38)

To fix the problem, we need to replace the overly permissive character range `！-～` with more specific ranges that cover only the intended characters. The goal is to ensure that only full-width alphanumeric characters and specific punctuation marks are matched and converted to their half-width counterparts.

- Replace the range `！-～` with specific ranges for full-width alphanumeric characters and punctuation marks.
- Update the regular expression on line 346 to use the corrected ranges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
